### PR TITLE
Add read contract functions and render correct amounts + total

### DIFF
--- a/packages/dapp/src/components/AddMilestones.jsx
+++ b/packages/dapp/src/components/AddMilestones.jsx
@@ -28,7 +28,7 @@ import {
 import { addMilestones, addMilestonesWithDetails } from '../utils/invoice';
 import { uploadMetadata } from '../utils/ipfs';
 
-export const AddMilestones = ({ invoice, due }) => {
+export const AddMilestones = ({ invoice, due, updateInvoice }) => {
   const { chainId, provider } = useContext(Web3Context);
   const {
     address,
@@ -52,8 +52,9 @@ export const AddMilestones = ({ invoice, due }) => {
   const [milestoneAmounts, setMilestoneAmounts] = useState([]);
   const [addedTotalInvalid, setAddedTotalInvalid] = useState(false);
   const [addedMilestonesInvalid, setAddedMilestonesInvalid] = useState(false);
-  const [revisedProjectAgreement, setRevisedProjectAgreement] =
-    useState(projectAgreement);
+  const [revisedProjectAgreement, setRevisedProjectAgreement] = useState(
+    projectAgreement,
+  );
 
   const buttonSize = useBreakpointValue({ base: 'md', md: 'lg' });
 
@@ -86,6 +87,7 @@ export const AddMilestones = ({ invoice, due }) => {
       setTransaction(tx);
       await tx.wait();
       window.location.href = `/invoice/${getHexChainId(network)}/${address}`;
+      await updateInvoice(provider, address);
     } catch (addMilestonesError) {
       setLoading(false);
       logError({ addMilestonesError });

--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -48,9 +48,9 @@ export const CONFIG = {
       },
     },
     4: {
-      SUBGRAPH: 'psparacino/rinkeby-smart-invoice-ps',
+      SUBGRAPH: 'psparacino/dev-only-smart-invoice-rinkeby',
       WRAPPED_NATIVE_TOKEN: '0xc778417E063141139Fce010982780140Aa0cD5Ab'.toLowerCase(),
-      INVOICE_FACTORY: '0xD4F1fB1ff28d5F927607F06eb5801c9398f982FD'.toLowerCase(),
+      INVOICE_FACTORY: '0x36fd33B2976C03444e8694cd2904457095289750'.toLowerCase(),
       TOKENS: {
         ['0xc778417E063141139Fce010982780140Aa0cD5Ab'.toLowerCase()]: {
           decimals: 18,

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -124,6 +124,7 @@ export const addMilestones = async (ethersProvider, address, amounts) => {
   const contract = new Contract(address, abi, ethersProvider.getSigner());
   return contract.addMilestones(amounts);
 };
+
 export const addMilestonesWithDetails = async (
   ethersProvider,
   address,
@@ -135,6 +136,30 @@ export const addMilestonesWithDetails = async (
   ]);
   const contract = new Contract(address, abi, ethersProvider.getSigner());
   return contract.addMilestones(amounts, details);
+};
+
+export const getAmounts = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function getAmounts() public view returns (uint256[] memory)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider.getSigner());
+  return contract.getAmounts();
+};
+
+export const getDetails = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function details() public view returns (bytes32)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider.getSigner());
+  return contract.details();
+};
+
+export const getTotal = async (ethersProvider, address) => {
+  const abi = new utils.Interface([
+    'function total() public view returns (uint256)',
+  ]);
+  const contract = new Contract(address, abi, ethersProvider.getSigner());
+  return contract.total();
 };
 
 export const verify = async (ethersProvider, address) => {


### PR DESCRIPTION
This method allows the dapp to read the amounts and total directly from the contract. If the values differ (is greater than) from the values from the subgraph, then dapp will display the values directly from the contract. The method is used twice: on page load and after addMilestones() transaction.

Currently, this does not include details if that was also updated in the addMilestones() transaction. In other words, it will only display the original details from the subgraph for now.