### PR TITLE
dedicated gateway and automatic infura pin for token metadata upload

### DIFF
--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -15,6 +15,7 @@
     "@react-pdf/renderer": "^2.3.0",
     "@walletconnect/web3-provider": "^1.4.1",
     "base-58": "^0.0.1",
+    "dotenv": "^16.0.1",
     "ethers": "^5.1.0",
     "fake-tag": "^2.0.0",
     "firebase": "^9.8.4",

--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -2,15 +2,13 @@ import LexDAOLogo from './assets/lex-dao.png';
 
 export const CONFIG = {
   INFURA_ID: process.env.REACT_APP_INFURA_ID,
-  IPFS_ENDPOINT: 'https://ipfs.infura.io',
+  IPFS_ENDPOINT: 'https://smart-invoice.infura-ipfs.io',
   BOX_ENDPOINT: 'https://ipfs.3box.io',
   NETWORK_CONFIG: {
     1: {
       SUBGRAPH: 'dan13ram/mainnet-smart-invoices',
-      WRAPPED_NATIVE_TOKEN:
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'.toLowerCase(),
-      INVOICE_FACTORY:
-        '0xb7019c3670f5d4dd99166727a7d29f8a16f4f20a'.toLowerCase(),
+      WRAPPED_NATIVE_TOKEN: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'.toLowerCase(),
+      INVOICE_FACTORY: '0xb7019c3670f5d4dd99166727a7d29f8a16f4f20a'.toLowerCase(),
       RESOLVERS: {
         ['0x01b92e2c0d06325089c6fd53c98a214f5c75b2ac'.toLowerCase()]: {
           name: 'LexDAO',
@@ -22,10 +20,8 @@ export const CONFIG = {
     },
     100: {
       SUBGRAPH: 'dan13ram/xdai-smart-invoices',
-      WRAPPED_NATIVE_TOKEN:
-        '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'.toLowerCase(),
-      INVOICE_FACTORY:
-        '0x26832d296Be653C1A818B7AaF3D4e5e16A0C314d'.toLowerCase(),
+      WRAPPED_NATIVE_TOKEN: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'.toLowerCase(),
+      INVOICE_FACTORY: '0x26832d296Be653C1A818B7AaF3D4e5e16A0C314d'.toLowerCase(),
       RESOLVERS: {
         ['0x034CfED494EdCff96f0D7160dC2B55Cae5Ee69E1'.toLowerCase()]: {
           name: 'LexDAO',
@@ -37,10 +33,8 @@ export const CONFIG = {
     },
     4: {
       SUBGRAPH: 'psparacino/smart-invoices-rinkey-ps',
-      WRAPPED_NATIVE_TOKEN:
-        '0xc778417E063141139Fce010982780140Aa0cD5Ab'.toLowerCase(),
-      INVOICE_FACTORY:
-        '0x659912E406b11D457656468c655F2e545E552259'.toLowerCase(),
+      WRAPPED_NATIVE_TOKEN: '0xc778417E063141139Fce010982780140Aa0cD5Ab'.toLowerCase(),
+      INVOICE_FACTORY: '0x659912E406b11D457656468c655F2e545E552259'.toLowerCase(),
       RESOLVERS: {
         ['0x1206b51217271FC3ffCa57d0678121983ce0390E'.toLowerCase()]: {
           name: 'LexDAO',

--- a/packages/dapp/src/tokenSupport/README.md
+++ b/packages/dapp/src/tokenSupport/README.md
@@ -9,11 +9,10 @@
             } , {Another Token...} ],
 
 2)  **Upload tokenSchema to IPFS (via CLI)** :
-    - You can upload with any preferred method. To quickly upload with the IPFS CLI:
-      - Install the IPFS CLI if needed [IPFS CLI Installation](https://docs.ipfs.io/install/command-line/#system-requirements)
-      - Open a terminal and enter `ipfs daemon`
-      - Enter the same directory as the updated tokenSchema and enter `ipfs add <filename`
-      - Copy the CID that will appear on successful upload (ex. format: QmYFLxr9F3ykXNkxhwNffDdhEm1RWUf5WrxHdP8AUnS5B9)
+    - Update tokenSchema.json with new token information according to schema above
+    - cd into packages/dapp/src/tokenSupport
+    - enter `node uploadTokenInfo.js' in the terminal
+    - you will receive: `[ { hash: <CID HASH HERE> } ]`
 3)  **Copy New CID into Firebase** :
     - You will need to be granted permission in order to login to Firebase and update token information.
       - Go to [Firebase Console](https://console.firebase.google.com/)
@@ -22,6 +21,6 @@
       - On the left hand side bar, select "Realtime Database".
       - Replace the old CID following `CID` with the new CID
 
-The supported tokens will now be updated in the app..
+The supported tokens will now be updated in the app.
 
 Note: the firebase-CID-template.json file is included if at some point there are frequent token modifications and using the firebase CLI becomes the preferred method of updating.

--- a/packages/dapp/src/tokenSupport/uploadTokenInfo.js
+++ b/packages/dapp/src/tokenSupport/uploadTokenInfo.js
@@ -1,0 +1,37 @@
+const ipfsClient = require('ipfs-http-client');
+require('dotenv').config({ path: '../../.env' });
+const tokenSchema = require('./tokenSchema.json');
+
+const {
+  REACT_APP_INFURA_PROJECT_ID,
+  REACT_APP_INFURA_PROJECT_SECRET,
+} = process.env;
+
+const auth =
+  'Basic ' +
+  Buffer.from(
+    `${REACT_APP_INFURA_PROJECT_ID}` +
+      ':' +
+      `${REACT_APP_INFURA_PROJECT_SECRET}`,
+  ).toString('base64');
+
+const client = new ipfsClient({
+  host: 'ipfs.infura.io',
+  port: 5001,
+  protocol: 'https',
+  headers: {
+    authorization: auth,
+  },
+});
+
+const uploadTokenData = async tokenSchema => {
+  const objectString = JSON.stringify(tokenSchema);
+  const bufferedString = Buffer.from(objectString);
+  const [res] = await client.add(bufferedString);
+
+  await client.pin.add(res.hash).then(res => {
+    console.log(res);
+  });
+};
+
+uploadTokenData(tokenSchema);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9690,6 +9690,11 @@ dotenv@8.2.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz"


### PR DESCRIPTION
it looks like infura shut down their public ipfs gateway today:

![Screen Shot 2022-08-10 at 2 48 42 PM](https://user-images.githubusercontent.com/72105234/183993465-51e7f7d4-1398-4333-b711-6e468f04f321.png)

This PR updates the app so we're using a dedicated gateway.

Also, I updated the token upload method to be more robust for the IPFS upload process and automatically pin on upload through Infura. 