### PR TITLE
Mainnet deployment of contract and subgraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ packages/subgraph/src/types
 
 # yarn version
 .yarn*
+
+# firebase tmp
+.firebase/

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -54,7 +54,7 @@ module.exports = {
     mainnet: {
       url: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
       accounts: [`0x${PRIVATE_KEY}`],
-      gasPrice: 4500000000,
+      gasPrice: 22000000000,
     },
   },
   etherscan: {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,6 +15,7 @@
     "lint": "solhint contracts/{*,**/*}.sol",
     "deploy-local": "hardhat run scripts/deploy-factory-local.js --network localhost",
     "deploy-kovan": "hardhat run scripts/deploy-factory.js --network kovan",
+    "deploy-mainnet": "hardhat run scripts/deploy-factory.js --network mainnet",
     "deploy-rinkeby": "hardhat run scripts/deploy-factory.js --network rinkeby",
     "deploy-sokol": "hardhat run scripts/deploy-factory.js --network sokol",
     "deploy-xdai": "hardhat run scripts/deploy-factory.js --network xdai",

--- a/packages/dapp/public/manifest.json
+++ b/packages/dapp/public/manifest.json
@@ -6,7 +6,7 @@
   "providedBy": { "name": "Raid Guild", "url": "https://raidguild.org" },
   "icons": [
     {
-      "src": "favicon.ic",
+      "src": "favicon.ico",
       "sizes": "192x192",
       "type": "image/png"
     },

--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -6,9 +6,9 @@ export const CONFIG = {
   BOX_ENDPOINT: 'https://ipfs.3box.io',
   NETWORK_CONFIG: {
     1: {
-      SUBGRAPH: 'dan13ram/mainnet-smart-invoices',
+      SUBGRAPH: 'mainnet-smart-invoice/v0.0.1',
       WRAPPED_NATIVE_TOKEN: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'.toLowerCase(),
-      INVOICE_FACTORY: '0xb7019c3670f5d4dd99166727a7d29f8a16f4f20a'.toLowerCase(),
+      INVOICE_FACTORY: '0xb5b23a79f0d293b5c567a9b8ff6f678daa7770b3'.toLowerCase(),
       RESOLVERS: {
         ['0x01b92e2c0d06325089c6fd53c98a214f5c75b2ac'.toLowerCase()]: {
           name: 'LexDAO',

--- a/packages/dapp/src/utils/constants.js
+++ b/packages/dapp/src/utils/constants.js
@@ -64,7 +64,7 @@ export const nativeSymbols = {
 };
 
 export const graphUrls = {
-  1: `https://api.thegraph.com/subgraphs/name/${NETWORK_CONFIG[1].SUBGRAPH}`,
+  1: `https://api.studio.thegraph.com/query/28985/${NETWORK_CONFIG[1].SUBGRAPH}`,
   4: `https://api.thegraph.com/subgraphs/name/${NETWORK_CONFIG[4].SUBGRAPH}`,
   100: `https://api.thegraph.com/subgraphs/name/${NETWORK_CONFIG[100].SUBGRAPH}`,
 };

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -15,10 +15,10 @@
     "deploy-only-rinkeby": "graph deploy psparacino/rinkeby-smart-invoice-ps --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "dev-deploy-only-rinkey": "yarn prepare-rinkeby && yarn codegen && yarn build && graph deploy psparacino/smart-invoices-rinkey-ps --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy-only-xdai": "graph deploy psparacino/xdai-smart-invoices --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
-    "deploy-only-mainnet": "graph deploy dan13ram/mainnet-smart-invoices --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
+    "deploy-only-mainnet": "graph deploy --studio psparacino/mainnet-smart-invoice --ipfs https://api.thegraph.com/ipfs/ --debug",
     "deploy-rinkeby": "yarn prepare-rinkeby && yarn codegen && yarn build && yarn deploy-only-rinkeby",
     "deploy-xdai": "yarn prepare-xdai && yarn codegen && yarn build && yarn deploy-only-xdai",
-    "deploy-mainnet": "yarn prepare-mainnet && yarn codegen && yarn build && yarn deploy-only-mainnet",
+    "deploy-mainnet-graph": "yarn prepare-mainnet && yarn codegen && yarn build && yarn deploy-only-mainnet",
     "deploy-fork": "yarn codegen && yarn build && graph create --node http://localhost:8020 SmartInvoiceFactoryVersion06 && graph deploy SmartInvoiceFactoryVersion06 --debug-fork QmNPv6LWg9tFtLf4BaXTHGE34vUFaFHAgsUznnC8XXmMdu --ipfs http://localhost:5001 --node http://localhost:8020"
   },
   "license": "MIT",

--- a/packages/subgraph/src/config/mainnet.json
+++ b/packages/subgraph/src/config/mainnet.json
@@ -3,8 +3,8 @@
   "factories": [
     {
       "factoryName": "Version00",
-      "startBlock": "12803981",
-      "address": "0xb7019c3670f5d4dd99166727a7d29f8a16f4f20a"
+      "startBlock": "15497149",
+      "address": "0xb5b23a79f0d293b5c567a9b8ff6f678daa7770b3"
     }
   ]
 }


### PR DESCRIPTION
Subgraph is in the subgraph studio now instead of the Hosted Service, as hosted service mainnet support is supposedly ending in a couple weeks.

mainnet contract deployment: https://etherscan.io/tx/0xe4e29e6b8bd048daa995f574dba9fd24fb2340f397151b47b9752766edec50a6