### PR TITLE
Fix/responsive dashboard

### DIFF
--- a/packages/dapp/.firebaserc
+++ b/packages/dapp/.firebaserc
@@ -1,5 +1,7 @@
 {
   "projects": {
-    "default": "smart-invoice-b0db1"
-  }
+    "default": "smart-invoice-b0db1",
+    "smart-invoice": "smart-invoice-b0db1"
+  },
+  "targets": {}
 }

--- a/packages/dapp/src/components/InvoiceDashboardTable.jsx
+++ b/packages/dapp/src/components/InvoiceDashboardTable.jsx
@@ -13,16 +13,10 @@ import {
   MenuItem,
   HStack,
 } from '@chakra-ui/react';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { withRouter, Link as RouterLink } from 'react-router-dom';
-import { useTable, useSortBy, usePagination, useRowSelect } from 'react-table';
+import React, { useMemo } from 'react';
+import { useTable, useSortBy, usePagination } from 'react-table';
 import { Loader } from './Loader';
-import { SearchContext, SearchContextProvider } from '../context/SearchContext';
-import { Web3Context } from '../context/Web3Context';
 import { useInvoiceStatus } from '../hooks/useInvoiceStatus';
-import { Container } from '../shared/Container';
-import { TriangleDownIcon, TriangleUpIcon } from '@chakra-ui/icons';
-import { theme } from '../theme';
 import { dateTimeToDate, getTokenInfo, getHexChainId } from '../utils/helpers';
 import { unixToDateTime } from '../utils/invoice';
 import { formatUnits } from 'ethers/lib/utils';
@@ -234,6 +228,15 @@ export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
                     })}
                     {...column.getHeaderProps(column.getSortByToggleProps())}
                     isnumeric={column.isnumeric}
+                    className={
+                      column.Header === 'Amount'
+                        ? 'noAmount'
+                        : column.Header === 'Currency'
+                        ? 'noCurrency'
+                        : column.Header === 'Date Created'
+                        ? 'noDate'
+                        : null
+                    }
                   >
                     <Text textColor={column.isSorted ? 'black' : 'blue.dark'}>
                       {column.render('Header')}
@@ -260,11 +263,17 @@ export function InvoiceDashboardTable({ result, tokenData, chainId, history }) {
                         // docs for react-table
                         {...cell.getCellProps({
                           className: cell.column.collapse ? 'collapse' : '',
-                          // style: {backgroundColor: 'green'},
                         })}
+                        className={
+                          cell.column.id === 'amount'
+                            ? 'noAmount'
+                            : cell.column.id === 'currency'
+                            ? 'noCurrency'
+                            : cell.column.id === 'createdAt'
+                            ? 'noDate'
+                            : null
+                        }
                       >
-                        {/* {console.log("cell props", cell.column.Header)} */}
-                        {/* {console.log("cell:", cell)} */}
                         {cell.render('Cell')}
                       </td>
                     );

--- a/packages/dapp/src/pages/InvoicesStyles.jsx
+++ b/packages/dapp/src/pages/InvoicesStyles.jsx
@@ -66,7 +66,7 @@ export const Styles = styled.div`
     }
   }
 
-  @media (max-width: 1062px) {
+  @media (max-width: 1074px) {
     .noAmount {
       display: none;
     }

--- a/packages/dapp/src/pages/InvoicesStyles.jsx
+++ b/packages/dapp/src/pages/InvoicesStyles.jsx
@@ -66,6 +66,41 @@ export const Styles = styled.div`
     }
   }
 
+  @media (max-width: 1062px) {
+    .noAmount {
+      display: none;
+    }
+  }
+
+  @media (max-width: 966px) {
+    .noCurrency {
+      display: none;
+    }
+  }
+  @media (max-width: 686px) {
+    .noDate {
+      display: none;
+    }
+  }
+  @media (max-width: 450px) {
+    table {
+      th {
+        :last-child {
+          border-right: 0;
+          text-align: right;
+        }
+      }
+
+      td {
+        :last-child {
+          border-right: 0;
+          text-align: right;
+          padding-right: 5%;
+        }
+      }
+    }
+  }
+
   .pagination {
     padding: 0.5rem;
     display: flex;


### PR DESCRIPTION
The current dashboard is a table; the cleanest solution to make it responsive seemed to be eliminating columns as dictated by screen width.

Amount, Currency, and Date Created are eliminated, in that order.

All Columns:
![Screen Shot 2022-09-21 at 2 24 22 PM](https://user-images.githubusercontent.com/72105234/191582480-ed33d908-c5ad-4d20-83dc-22328a6bb11a.png)

No Amount
![Screen Shot 2022-09-21 at 2 25 49 PM](https://user-images.githubusercontent.com/72105234/191582608-9a3d5cf3-c22c-4ee0-885d-6f67d2fd6f78.png)

No Currency
![Screen Shot 2022-09-21 at 2 25 55 PM](https://user-images.githubusercontent.com/72105234/191582639-60b83aec-9ae4-4ff3-9c58-89a4fcd7e546.png)

No Date
![Screen Shot 2022-09-21 at 2 26 06 PM](https://user-images.githubusercontent.com/72105234/191582660-cd562429-92c5-475b-9342-ec20e4b8b7d5.png)
