### PR TITLE
Alert if user tries to deposit more than their current balance

### DIFF
--- a/packages/dapp/src/components/DepositFunds.jsx
+++ b/packages/dapp/src/components/DepositFunds.jsx
@@ -56,8 +56,15 @@ export const DepositFunds = ({ invoice, deposited, due, tokenData }) => {
   const [loading, setLoading] = useState(false);
   const [transaction, setTransaction] = useState();
   const buttonSize = useBreakpointValue({ base: 'md', md: 'lg' });
+  const [depositError, setDepositError] = useState(false);
+
   const deposit = async () => {
     if (!amount || !provider) return;
+    if (
+      utils.formatUnits(amount, decimals) > utils.formatUnits(balance, decimals)
+    )
+      return setDepositError(true);
+
     try {
       setLoading(true);
       let tx;
@@ -97,6 +104,15 @@ export const DepositFunds = ({ invoice, deposited, due, tokenData }) => {
     }
   }, [paymentType, token, provider, account]);
 
+  useEffect(() => {
+    if (
+      depositError &&
+      utils.formatUnits(balance, decimals) > utils.formatUnits(amount, decimals)
+    ) {
+      setDepositError(false);
+    }
+  }, [depositError, amount, balance]);
+
   return (
     <VStack w="100%" spacing="1rem">
       <Heading
@@ -112,6 +128,16 @@ export const DepositFunds = ({ invoice, deposited, due, tokenData }) => {
         At a minimum, you’ll need to deposit enough to cover the{' '}
         {currentMilestone === 0 ? 'first' : 'next'} project payment.
       </Text>
+      {depositError ? (
+        <Flex>
+          <Alert bg="none" margin="0 auto" textAlign="center" padding="0">
+            <AlertIcon color="red.500" />
+            <AlertTitle fontSize="sm" color="red.500">
+              Not enough available {symbol} for this deposit
+            </AlertTitle>
+          </Alert>
+        </Flex>
+      ) : null}
 
       <Text textAlign="center" color="black">
         How much will you be depositing today?


### PR DESCRIPTION
Current flow is that the alert will appear if user clicks deposit and their token balance < deposit amount. The alert will stay until they enter a lower amount.

The alert doesn't show every time that the deposit amount is > balance so that the alert won't keep flashing in and out as they entering or adjusting their deposit.

![Screen Shot 2022-10-05 at 12 37 36 PM](https://user-images.githubusercontent.com/72105234/194119329-0257bbcf-3744-4869-a2ef-a4b16e50c3a2.png)
